### PR TITLE
[NUC DEMO] Add intel nuc target as intel-corei7-64

### DIFF
--- a/.bbtravis.yml
+++ b/.bbtravis.yml
@@ -8,6 +8,7 @@ env:
   matrix:
   - TARGET=qemux86-64
   - TARGET=raspberrypi3
+  - TARGET=intel-corei7-64
 
 # Tests running commands
 script:

--- a/.gitmodules
+++ b/.gitmodules
@@ -38,3 +38,6 @@
 [submodule "meta-qcom"]
     path = meta-qcom
     url = git://git.yoctoproject.org/meta-qcom
+[submodule "meta-radioservice"]
+	path = meta-radioservice
+	url = https://github.com/Forestscribe/meta-radioservice.git

--- a/gdp-src-build/conf/templates/intel-corei7-64.bblayers.conf
+++ b/gdp-src-build/conf/templates/intel-corei7-64.bblayers.conf
@@ -1,0 +1,8 @@
+include templates/bblayers.inc
+
+# minnowboard specific layer configuration
+BBLAYERS += " \
+  ${TOPDIR}/../meta-genivi-dev/meta-intel-gdp \
+  ${TOPDIR}/../meta-intel \
+  ${TOPDIR}/../meta-radioservice \
+  "

--- a/gdp-src-build/conf/templates/intel-corei7-64.local.conf
+++ b/gdp-src-build/conf/templates/intel-corei7-64.local.conf
@@ -1,0 +1,15 @@
+include templates/local.inc
+
+MACHINE = "intel-corei7-64"
+MACHINE_FEATURES_append = " sgx"
+MULTI_PROVIDER_WHITELIST += "virtual/libgl virtual/egl virtual/libgles1 virtual/libgles2"
+PREFERRED_PROVIDER_virtual/libgles1 = ""
+PREFERRED_PROVIDER_virtual/libgles2 = ""
+PREFERRED_PROVIDER_virtual/egl = ""
+PREFERRED_PROVIDER_virtual/libgl = "opengl"
+PREFERRED_PROVIDER_virtual/mesa = ""
+PREFERRED_PROVIDER_libgbm = "libgbm"
+PREFERRED_PROVIDER_libgbm-dev = "libgbm"
+SDKIMAGE_FEATURES_append = " staticdev-pkgs"
+IMAGE_INSTALL_append = " mesa-megadriver packagegroup-radiodemo"
+SERIAL_CONSOLES = "115200;ttyUSB0"

--- a/init.sh
+++ b/init.sh
@@ -17,8 +17,8 @@ fi
 
 echo "You selected target $choice"
 
-declare -a targets=("qemux86-64" "porter" "raspberrypi2" "raspberrypi3" "minnowboard" "silk" "dragonboard-410c")
-declare -a supported=("qemux86-64" "porter" "minnowboard" "raspberrypi2" "raspberrypi3" "dragonboard-410c" "silk")
+declare -a targets=("intel-corei7-64" "qemux86-64" "porter" "raspberrypi2" "raspberrypi3" "minnowboard" "silk" "dragonboard-410c")
+declare -a supported=("intel-corei7-64" "qemux86-64" "porter" "minnowboard" "raspberrypi2" "raspberrypi3" "dragonboard-410c" "silk")
 declare -a variables=("choice" "eula" "machine" "modules" "bsp" "bsparr" "supported" "targets" "variables")
 
 for i in ${targets[@]}; do
@@ -74,7 +74,7 @@ echo "Local & bblayers conf set for $machine"
 # bsp submodule layer
 declare -A bsparr
 
-bsparr+=( ["minnowboard"]="meta-intel" ["raspberrypi2"]="meta-raspberrypi" ["raspberrypi3"]="meta-raspberrypi" ["porter"]="meta-renesas" ["silk"]="meta-renesas" ["dragonboard-410c"]="meta-qcom" )
+bsparr+=( ["intel-corei7-64"]="meta-intel" ["minnowboard"]="meta-intel" ["raspberrypi2"]="meta-raspberrypi" ["raspberrypi3"]="meta-raspberrypi" ["porter"]="meta-renesas" ["silk"]="meta-renesas" ["dragonboard-410c"]="meta-qcom" )
 
 modules=($(git submodule | awk '{ print $2 }'))
 for i in ${bsparr[@]}; do


### PR DESCRIPTION
- add intel-corei7-64 target
- add submodule meta-radioservice for FM demo
- install packagegroup-radiodemo on intel-corei7-64 for FM radio demo

Signed-off-by: Kevin Turban <turban.kevin@gmail.com>