### PR TITLE
Enable CAN support for RPI

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -44,4 +44,7 @@
 [submodule "meta-radioservice"]
 	path = meta-radioservice
 	url = https://github.com/Forestscribe/meta-radioservice.git
+[submodule "meta-forestscribe"]
+	path = meta-forestscribe
+	url = https://github.com/Forestscribe/meta-forestscribe.git
 

--- a/gdp-src-build/conf/templates/bblayers.inc
+++ b/gdp-src-build/conf/templates/bblayers.inc
@@ -22,6 +22,7 @@ BBLAYERS ?= " \
   ${TOPDIR}/../meta-erlang \
   ${TOPDIR}/../meta-rvi \
   ${TOPDIR}/../meta-browser \
+  ${TOPDIR}/../meta-forestscribe/meta-forestscribe \
   "
 
 BBLAYERS_NON_REMOVABLE ?= " \

--- a/gdp-src-build/conf/templates/raspberrypi.local.inc
+++ b/gdp-src-build/conf/templates/raspberrypi.local.inc
@@ -18,3 +18,5 @@ PREFERRED_PROVIDER_virtual/libgles2 = "mesa"
 PREFERRED_PROVIDER_virtual/libgl = "mesa"
 PREFERRED_PROVIDER_virtual/mesa = "mesa"
 PREFERRED_PROVIDER_jpeg = "jpeg"
+
+MACHINE_FEATURES += "can"

--- a/gdp-src-build/conf/templates/raspberrypi2.bblayers.conf
+++ b/gdp-src-build/conf/templates/raspberrypi2.bblayers.conf
@@ -2,6 +2,7 @@ include templates/bblayers.inc
 
 # raspberrypi2 specific layer configuration
 BBLAYERS += " \
+  ${TOPDIR}/../meta-forestscribe/meta-raspberrypi-fs \
   ${TOPDIR}/../meta-genivi-dev/meta-raspberrypi-gdp \
   ${TOPDIR}/../meta-raspberrypi \
   "

--- a/gdp-src-build/conf/templates/raspberrypi3.bblayers.conf
+++ b/gdp-src-build/conf/templates/raspberrypi3.bblayers.conf
@@ -2,6 +2,7 @@ include templates/bblayers.inc
 
 # raspberrypi3 specific layer configuration
 BBLAYERS += " \
+  ${TOPDIR}/../meta-forestscribe/meta-raspberrypi-fs \
   ${TOPDIR}/../meta-genivi-dev/meta-raspberrypi-gdp \
   ${TOPDIR}/../meta-raspberrypi \
   "


### PR DESCRIPTION
Add:
- RPI CAN support through mcp2515
- CAN package group which contains: iproute2, can-utils, python-can